### PR TITLE
Add tile helper class.

### DIFF
--- a/QGL_Math/QGLMath.h
+++ b/QGL_Math/QGLMath.h
@@ -8,3 +8,5 @@
 #include "include/Shapes/qgl_rectangle.h"
 #include "include/Shapes/qgl_aabb_helpers.h"
 #include "include/Shapes/qgl_boundary.h"
+
+#include "include/qgl_tile_helpers.h"

--- a/QGL_Math/QGL_Math.vcxproj
+++ b/QGL_Math/QGL_Math.vcxproj
@@ -153,6 +153,7 @@
     <ClInclude Include="include\qgl_math_funcs.h" />
     <ClInclude Include="include\qgl_math_includes.h" />
     <ClInclude Include="include\qgl_rational.h" />
+    <ClInclude Include="include\qgl_tile_helpers.h" />
     <ClInclude Include="include\Shapes\qgl_aabb_helpers.h" />
     <ClInclude Include="include\Shapes\qgl_boundary.h" />
     <ClInclude Include="include\Shapes\qgl_dx_comparators.h" />

--- a/QGL_Math/QGL_Math.vcxproj.filters
+++ b/QGL_Math/QGL_Math.vcxproj.filters
@@ -77,6 +77,9 @@
     <ClInclude Include="include\Shapes\qgl_boundary.h">
       <Filter>Header Files\Shapes</Filter>
     </ClInclude>
+    <ClInclude Include="include\qgl_tile_helpers.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="QGL_Math.def">

--- a/QGL_Math/include/Shapes/qgl_dx_comparators.h
+++ b/QGL_Math/include/Shapes/qgl_dx_comparators.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "include/qgl_math_includes.h"
+#include "include/qgl_math_funcs.h"
 
 namespace qgl::math
 {
@@ -7,8 +8,8 @@ namespace qgl::math
    inline bool operator==(const DirectX::XMFLOAT2& a,
       const DirectX::XMFLOAT2& b) noexcept
    {
-      return approx_equal(a.x, b.x) &&
-         approx_equal(a.y, b.y);
+      return approx_equal(a.x, b.x, FLT_EPSILON) &&
+         approx_equal(a.y, b.y, FLT_EPSILON);
    }
 
    inline bool operator!=(const DirectX::XMFLOAT2& a,
@@ -20,9 +21,9 @@ namespace qgl::math
    inline bool operator==(const DirectX::XMFLOAT3& a,
       const DirectX::XMFLOAT3& b) noexcept
    {
-      return approx_equal(a.x, b.x) &&
-         approx_equal(a.y, b.y) &&
-         approx_equal(a.z, b.z);
+      return approx_equal(a.x, b.x, FLT_EPSILON) &&
+         approx_equal(a.y, b.y, FLT_EPSILON) &&
+         approx_equal(a.z, b.z, FLT_EPSILON);
    }
 
    inline bool operator!=(const DirectX::XMFLOAT3& a,
@@ -34,16 +35,78 @@ namespace qgl::math
    inline bool operator==(const DirectX::XMFLOAT4& a,
       const DirectX::XMFLOAT4& b) noexcept
    {
-      return approx_equal(a.x, b.x) &&
-         approx_equal(a.y, b.y) &&
-         approx_equal(a.z, b.z) &&
-         approx_equal(a.w, b.w);
+      return approx_equal(a.x, b.x, FLT_EPSILON) &&
+         approx_equal(a.y, b.y, FLT_EPSILON) &&
+         approx_equal(a.z, b.z, FLT_EPSILON) &&
+         approx_equal(a.w, b.w, FLT_EPSILON);
    }
 
    inline bool operator!=(const DirectX::XMFLOAT4& a,
       const DirectX::XMFLOAT4& b) noexcept
    {
       return !(a == b);
+   }
+
+   ////////////Overload equality operators for DirectX CPU matrices.////////////
+   inline bool operator==(const DirectX::XMFLOAT4X4& a,
+                          const DirectX::XMFLOAT4X4 b) noexcept
+   {
+      bool ret = true;
+      for (size_t r = 0; r < 4; r++)
+      {
+         for (size_t c = 0; c < 4; c++)
+         {
+            ret &= (a(r, c) == b(r, c));
+         }
+      }
+
+      return ret;
+   }
+
+   inline bool operator!=(const DirectX::XMFLOAT4X4& a,
+                          const DirectX::XMFLOAT4X4 b) noexcept
+   {
+      return !(a == b);
+   }
+
+   //////////Overload equality operators for DirectX hardware vectors.//////////
+   inline bool XM_CALLCONV operator==(
+      DirectX::FXMVECTOR a,
+      DirectX::FXMVECTOR b) noexcept
+   {
+      auto cmp = DirectX::XMVectorEqual(a, b);
+      return DirectX::XMVectorGetX(cmp) != 0 &&
+         DirectX::XMVectorGetY(cmp) != 0 &&
+         DirectX::XMVectorGetZ(cmp) != 0 &&
+         DirectX::XMVectorGetW(cmp) != 0;
+   }
+
+   inline bool XM_CALLCONV operator!=(
+      DirectX::FXMVECTOR a,
+      DirectX::FXMVECTOR b) noexcept
+   {
+      return !(a == b);
+   }
+
+   //////////Overload equality operators for DirectX hardware matrices./////////
+   inline bool XM_CALLCONV operator==(
+      DirectX::FXMMATRIX m1,
+      DirectX::CXMMATRIX m2) noexcept
+   {
+      DirectX::XMFLOAT4X4 m1F;
+      DirectX::XMFLOAT4X4 m2F;
+
+      DirectX::XMStoreFloat4x4(&m1F, m1);
+      DirectX::XMStoreFloat4x4(&m2F, m2);
+
+      return m1F == m2F;
+   }
+
+   inline bool XM_CALLCONV operator!=(
+      DirectX::FXMMATRIX m1,
+      DirectX::CXMMATRIX m2) noexcept
+   {
+      return !(m1 == m2);
    }
 
    /////////Overload equality operators for DirectX bounding volumes.///////////

--- a/QGL_Math/include/qgl_math_funcs.h
+++ b/QGL_Math/include/qgl_math_funcs.h
@@ -1,17 +1,12 @@
 #pragma once
-#include "include/qgl_math_funcs.h"
+#include "include/qgl_math_includes.h"
 
 namespace qgl::math
 {
    template<typename T>
-   constexpr T absolute_value(T x) noexcept
+   inline T absolute_value(T x) noexcept
    {
-      if (x < 0)
-      {
-         return -x;
-      }
-
-      return x;
+      return std::abs(x);
    }
 
    /*
@@ -19,31 +14,61 @@ namespace qgl::math
     tolerance.
     */
    template<typename T>
-   constexpr bool approx_equal(T expected,
-      T actual,
-      T tolerance) noexcept
+   inline bool approx_equal(T expected,
+                                      T actual,
+                                      T tolerance) noexcept
    {
       return absolute_value(expected - actual) <= tolerance;
    }
 
    /*
     Specialization of approx_equal for floats.
+    Use FLT_EPSILON for the tolerance.
     */
-   constexpr bool approx_equal(float expected,
-      float actual,
-      float tolerance = FLT_EPSILON) noexcept
+   template<>
+   inline bool approx_equal<float>(float expected,
+                                             float actual,
+                                             float tolerance) noexcept
    {
       return absolute_value(expected - actual) <= tolerance;
    }
 
    /*
     Specialization of approx_equal for doubles.
+    Use DBL_EPSILON for the tolerance.
     */
-   constexpr bool approx_equal(double expected,
-      double actual,
-      double tolerance = DBL_EPSILON) noexcept
+   template<>
+   inline bool approx_equal<double>(double expected,
+                                              double actual,
+                                              double tolerance) noexcept
    {
       return absolute_value(expected - actual) <= tolerance;
+   }
+
+   template<typename RetT>
+   inline RetT ceiling(float x) noexcept
+   {
+      static_assert(std::is_integral<RetT>::value,
+                    "The return type RetT must be integral.");
+
+      // Cast x to an int and then back to a float. If the casted value equals
+      // the original value, then no need to round up.
+      return static_cast<RetT>(std::ceilf(x));
+   }
+
+   template<typename RetT>
+   inline RetT ceiling(double x) noexcept
+   {
+      static_assert(std::is_integral<RetT>::value,
+                    "The return type RetT must be integral.");
+
+      return static_cast<RetT>(std::ceil(x));
+   }
+
+   template<typename RetT>
+   inline RetT XM_CALLCONV ceiling(DirectX::FXMVECTOR x) noexcept
+   {
+      return DirectX::XMVectorCeiling(x);
    }
 
    /*
@@ -65,7 +90,8 @@ namespace qgl::math
    inline float round_up<float>(float val, float nearest) noexcept
    {
       auto remainder = fmod(val, nearest);
-      return approx_equal(remainder, 0.0f) ? val : val + nearest - remainder;
+      return approx_equal(remainder, 0.0f, FLT_EPSILON) ?
+         val : val + nearest - remainder;
    }
 
    /*
@@ -75,7 +101,8 @@ namespace qgl::math
    inline double round_up<double>(double val, double nearest) noexcept
    {
       auto remainder = fmod(val, nearest);
-      return approx_equal(remainder, 0.0) ? val : val + nearest - remainder;
+      return approx_equal(remainder, 0.0, LDBL_EPSILON) ?
+         val : val + nearest - remainder;
    }
 
    /*

--- a/QGL_Math/include/qgl_tile_helpers.h
+++ b/QGL_Math/include/qgl_tile_helpers.h
@@ -1,0 +1,111 @@
+#pragma once
+#include "include/qgl_math_includes.h"
+#include "include/qgl_math_funcs.h"
+
+/*
+ This namespace provides helper functions to convert between physical units,
+ such as meters, and tile units which are found in isometric games.
+ Geometry that is encoded in physical units like models or collision boundaries,
+ can be scaled to a tile based unit system with these helpers.
+
+ The helper functions are encapsulated in a class because they depend so much
+ on templates. Making them all free functions would create bloated code.
+ */
+namespace qgl::math::tiles
+{
+   /*
+    Converts physical units (like meters) to tile units based on a conversion
+    factor. The conversion factor is a compile-time constant.
+
+    TileT: The data type of the tile units. Must be an integer-like type.
+
+    PhysicalT: The data type of the physical units. This should probably be
+      a floating point type.
+
+    Physical: The number of physical units in a tile unit.
+      Ex: If a tile is 2 meters wide, then this value should be "2".
+
+    Tile: The denominator in the physical to tile ratio. By default this is 1,
+      but a the ratio can be inverted by specifying a number larger than
+      "Physical".
+
+    */
+   template<
+      typename TileT,
+      typename PhysicalT,
+      std::intmax_t Physical,
+      std::intmax_t Tile = 1>
+      class tile_helpers
+   {
+      private:
+      /*
+       Assert that the template parameters are correct.
+       */
+      static_assert(std::is_integral<TileT>::value,
+                    "TileT must be integral.");
+
+      static_assert(std::is_floating_point<PhysicalT>::value,
+                    "PhysicalT must be a floating point data type.");
+
+      typedef std::integral_constant<std::intmax_t, Tile> DenomConstant;
+      typedef std::integral_constant <std::intmax_t, 0> ZeroConstant;
+      static_assert(DenomConstant::value != ZeroConstant::value,
+                    "Denominator cannot be zero.");
+
+      public:
+
+      /*
+       Returns the physical to tile ratio.
+       */
+      static constexpr std::ratio<Physical, Tile> tile_ratio()
+      {
+         return std::ratio<Physical, Tile> {};
+      }
+
+      /*
+       Returns the physical to tile ratio as a real number.
+       */
+      static constexpr PhysicalT real() noexcept
+      {
+         return static_cast<PhysicalT>(Physical) / static_cast<PhysicalT>(Tile);
+      }
+
+      /*
+       Returns the tile to physical ratio as a real number.
+       */
+      static constexpr PhysicalT ireal() noexcept
+      {
+         return static_cast<PhysicalT>(Tile) / static_cast<PhysicalT>(Physical);
+      }
+
+      /*
+       Converts a physical unit to tile space. The result is rounded up to the
+       nearest tile.
+       */
+      static TileT to_tiles(PhysicalT p) noexcept
+      {
+         return math::ceiling<TileT>(ireal() * p);
+      }
+
+      /*
+       Converts a vector of physical units to a vector in tile space.
+       Each element is rounded up to the nearest tile.
+       */
+      static DirectX::XMVECTOR XM_CALLCONV to_tiles(DirectX::FXMVECTOR p) noexcept
+      {
+         return math::ceiling<DirectX::XMVECTOR>(DirectX::operator*(
+            ireal(), p));
+      }
+
+      /*
+       Creates a scale transform matrix that when multiplied by a physical
+       scaled vector, scales the vector to tile space.
+       */
+      static DirectX::XMMATRIX XM_CALLCONV tile_scale() noexcept
+      {
+         return DirectX::XMMatrixScaling(ireal(),
+                                         ireal(),
+                                         ireal());
+      }
+   };
+}

--- a/QGL_Model/include/Impl/fast_hash_impl.h
+++ b/QGL_Model/include/Impl/fast_hash_impl.h
@@ -56,15 +56,29 @@ namespace qgl::impl
 
       switch (len & 7)
       {
-         case 7: v ^= (uint64_t)pos2[6] << 48;
-         case 6: v ^= (uint64_t)pos2[5] << 40;
-         case 5: v ^= (uint64_t)pos2[4] << 32;
-         case 4: v ^= (uint64_t)pos2[3] << 24;
-         case 3: v ^= (uint64_t)pos2[2] << 16;
-         case 2: v ^= (uint64_t)pos2[1] << 8;
-         case 1: v ^= (uint64_t)pos2[0];
+         case 7: 
+            v ^= (uint64_t)pos2[6] << 48;
+            [[fallthrough]];
+         case 6: 
+            v ^= (uint64_t)pos2[5] << 40;
+            [[fallthrough]];
+         case 5: 
+            v ^= (uint64_t)pos2[4] << 32;
+            [[fallthrough]];
+         case 4: 
+            v ^= (uint64_t)pos2[3] << 24;
+            [[fallthrough]];
+         case 3: 
+            v ^= (uint64_t)pos2[2] << 16;
+            [[fallthrough]];
+         case 2: 
+            v ^= (uint64_t)pos2[1] << 8;
+            [[fallthrough]];
+         case 1: 
+            v ^= (uint64_t)pos2[0];
             h ^= mix(v);
             h *= m;
+            [[fallthrough]];
       }
 
       return mix(h);

--- a/QGL_Model/include/qgl_console.h
+++ b/QGL_Model/include/qgl_console.h
@@ -5,13 +5,13 @@
 namespace qgl
 {
    template<typename CharT>
-   void default_con_out(const std::basic_string<CharT>& s)
+   inline void default_con_out(const std::basic_string<CharT>& s)
    {
       OutputDebugStringA(s.c_str());
    }
 
    template<>
-   void default_con_out(const std::wstring& s)
+   inline void default_con_out<wchar_t>(const std::wstring& s)
    {
       OutputDebugStringW(s.c_str());
    }

--- a/Tests/QGL_Math.UnitTests/QGL_Math.UnitTests.vcxproj
+++ b/Tests/QGL_Math.UnitTests/QGL_Math.UnitTests.vcxproj
@@ -228,6 +228,7 @@
     <ClCompile Include="Tests\decimal_tests.cpp" />
     <ClCompile Include="Tests\rational_number_tests.cpp" />
     <ClCompile Include="Tests\rectangle_tests.cpp" />
+    <ClCompile Include="Tests\tile_helper_tests.cpp" />
     <ClCompile Include="UnitTestApp.xaml.cpp">
       <DependentUpon>UnitTestApp.xaml</DependentUpon>
     </ClCompile>

--- a/Tests/QGL_Math.UnitTests/QGL_Math.UnitTests.vcxproj.filters
+++ b/Tests/QGL_Math.UnitTests/QGL_Math.UnitTests.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClCompile Include="boundary_tests.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="Tests\tile_helper_tests.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />

--- a/Tests/QGL_Math.UnitTests/Tests/decimal_tests.cpp
+++ b/Tests/QGL_Math.UnitTests/Tests/decimal_tests.cpp
@@ -131,15 +131,18 @@ namespace QGL_Math_Unit_Tests
       TEST_METHOD(FloatConversion)
       {
          decimal<100> d1{ 10 };
-         Assert::IsTrue(approx_equal(0.1f, static_cast<float>(d1)),
+         Assert::IsTrue(
+            approx_equal(0.1f, static_cast<float>(d1), FLT_EPSILON),
             L"Should be 1/10");
 
          decimal<100> d2{};
-         Assert::IsTrue(approx_equal(0.0f, static_cast<float>(d2)),
+         Assert::IsTrue(
+            approx_equal(0.0f, static_cast<float>(d2), FLT_EPSILON),
             L"Should be 0.");
 
          decimal<10000> d3{ 3333 };
-         Assert::IsTrue(approx_equal(0.3333f, static_cast<float>(d3)),
+         Assert::IsTrue(
+            approx_equal(0.3333f, static_cast<float>(d3), FLT_EPSILON),
             L"Should be 1/3");
       }
 
@@ -150,15 +153,18 @@ namespace QGL_Math_Unit_Tests
       TEST_METHOD(DoubleConversion)
       {
          decimal<100> d1{ 10 };
-         Assert::IsTrue(approx_equal(0.1, static_cast<double>(d1)),
+         Assert::IsTrue(
+            approx_equal(0.1, static_cast<double>(d1), DBL_EPSILON),
             L"Should be 1/10");
 
          decimal<100> d2{};
-         Assert::IsTrue(approx_equal(0.0, static_cast<double>(d2)),
+         Assert::IsTrue(
+            approx_equal(0.0, static_cast<double>(d2), DBL_EPSILON),
             L"Should be 0.");
 
          decimal<10000> d3{ 3333 };
-         Assert::IsTrue(approx_equal(0.3333, static_cast<double>(d3)),
+         Assert::IsTrue(
+            approx_equal(0.3333, static_cast<double>(d3), DBL_EPSILON),
             L"Should be 1/3");
       }
    };

--- a/Tests/QGL_Math.UnitTests/Tests/rational_number_tests.cpp
+++ b/Tests/QGL_Math.UnitTests/Tests/rational_number_tests.cpp
@@ -10,7 +10,7 @@ namespace QGL_Math_Unit_Tests
    {
       public:
       /*
-       Construct a rational and verify its numerator and denominator are 
+       Construct a rational and verify its numerator and denominator are
        correct.
        */
       TEST_METHOD(Construct)
@@ -37,7 +37,7 @@ namespace QGL_Math_Unit_Tests
       }
 
       /*
-       Verify that constructing a rational with 0 as the denominator throws 
+       Verify that constructing a rational with 0 as the denominator throws
        std::invalid_argument.
        */
       TEST_METHOD(ConstructWith0Denom)
@@ -133,7 +133,7 @@ namespace QGL_Math_Unit_Tests
       }
 
       /*
-       Create a rational, convert it to a float and verify that float is 
+       Create a rational, convert it to a float and verify that float is
        approximately equal to an expected value.
        */
       TEST_METHOD(FloatConversion)
@@ -141,21 +141,26 @@ namespace QGL_Math_Unit_Tests
          rational<int> zero;
          rational<int> one(1, 1);
          rational<int> netagiveOne(-1, 1);
-         Assert::IsTrue(approx_equal(0.0f, static_cast<float>(zero)),
-                        L"Should be 0");
+         Assert::IsTrue(
+            approx_equal(0.0f, static_cast<float>(zero), FLT_EPSILON),
+            L"Should be 0");
 
-         Assert::IsTrue(approx_equal(1.0f, static_cast<float>(one)),
-                        L"Should be 1");
+         Assert::IsTrue(
+            approx_equal(1.0f, static_cast<float>(one), FLT_EPSILON),
+            L"Should be 1");
 
-         Assert::IsTrue(approx_equal(-1.0f, static_cast<float>(netagiveOne)),
-                        L"Should be -1");
+         Assert::IsTrue(
+            approx_equal(-1.0f, static_cast<float>(netagiveOne), FLT_EPSILON),
+            L"Should be -1");
 
          rational<int> oneTenth(1, 10);
-         Assert::IsTrue(approx_equal(0.1f, static_cast<float>(oneTenth)),
-                        L"Should be 1/10");
+         Assert::IsTrue(
+            approx_equal(0.1f, static_cast<float>(oneTenth), FLT_EPSILON),
+            L"Should be 1/10");
 
-         Assert::IsTrue(!approx_equal(0.099999f, static_cast<float>(oneTenth)),
-                        L"Should be 1/10");
+         Assert::IsTrue(
+            !approx_equal(0.099999f, static_cast<float>(oneTenth), FLT_EPSILON),
+            L"Should be 1/10");
       }
 
       /*
@@ -167,21 +172,26 @@ namespace QGL_Math_Unit_Tests
          rational<int> zero;
          rational<int> one(1, 1);
          rational<int> netagiveOne(-1, 1);
-         Assert::IsTrue(approx_equal(0.0, static_cast<double>(zero)),
-                        L"Should be 0");
+         Assert::IsTrue(
+            approx_equal(0.0, static_cast<double>(zero), DBL_EPSILON),
+            L"Should be 0");
 
-         Assert::IsTrue(approx_equal(1.0, static_cast<double>(one)),
-                        L"Should be 1");
+         Assert::IsTrue(
+            approx_equal(1.0, static_cast<double>(one), DBL_EPSILON),
+            L"Should be 1");
 
-         Assert::IsTrue(approx_equal(-1.0, static_cast<double>(netagiveOne)),
-                        L"Should be -1");
+         Assert::IsTrue(
+            approx_equal(-1.0, static_cast<double>(netagiveOne), DBL_EPSILON),
+            L"Should be -1");
 
          rational<int> oneTenth(1, 10);
-         Assert::IsTrue(approx_equal(0.1, static_cast<double>(oneTenth)),
-                        L"Should be 1/10");
+         Assert::IsTrue(
+            approx_equal(0.1, static_cast<double>(oneTenth), DBL_EPSILON),
+            L"Should be 1/10");
 
-         Assert::IsTrue(!approx_equal(0.099999, static_cast<double>(oneTenth)),
-                        L"Should be 1/10");
+         Assert::IsTrue(
+            !approx_equal(0.099999, static_cast<double>(oneTenth), DBL_EPSILON),
+            L"Should be 1/10");
       }
 
       /*
@@ -242,8 +252,9 @@ namespace QGL_Math_Unit_Tests
          Assert::AreEqual(rational<int>(3, 2), oneHalf / oneThird,
                           L"Should be 3/2");
 
-         Assert::IsTrue(approx_equal(1.5f, 
-                                     static_cast<float>(oneHalf / oneThird)),
+         Assert::IsTrue(approx_equal(1.5f,
+                                     static_cast<float>(oneHalf / oneThird),
+                                     FLT_EPSILON),
                         L"Should be 1.5");
       }
 

--- a/Tests/QGL_Math.UnitTests/Tests/rectangle_tests.cpp
+++ b/Tests/QGL_Math.UnitTests/Tests/rectangle_tests.cpp
@@ -175,13 +175,13 @@ namespace QGL_Math_Unit_Tests
 
          D2D_RECT_F expected{ 1.0f, -1.0f, 2.0f, 1.0f };
          auto actual = r.rect_2d();
-         Assert::IsTrue(approx_equal(expected.top, actual.top), 
+         Assert::IsTrue(approx_equal(expected.top, actual.top, FLT_EPSILON),
                         L"Tops are not equal.");
-         Assert::IsTrue(approx_equal(expected.right, actual.right),
+         Assert::IsTrue(approx_equal(expected.right, actual.right, FLT_EPSILON),
                         L"Rights are not equal.");
-         Assert::IsTrue(approx_equal(expected.left, actual.left),
+         Assert::IsTrue(approx_equal(expected.left, actual.left, FLT_EPSILON),
                         L"Lefts are not equal.");
-         Assert::IsTrue(approx_equal(expected.bottom, actual.bottom),
+         Assert::IsTrue(approx_equal(expected.bottom, actual.bottom, FLT_EPSILON),
                         L"Bottoms are not equal.");
       }
    };

--- a/Tests/QGL_Math.UnitTests/Tests/tile_helper_tests.cpp
+++ b/Tests/QGL_Math.UnitTests/Tests/tile_helper_tests.cpp
@@ -1,0 +1,61 @@
+#include "pch.h"
+#include "CppUnitTest.h"
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+using namespace qgl;
+using namespace qgl::math;
+using namespace qgl::math::tiles;
+
+namespace QGL_Math_Unit_Tests
+{
+   TEST_CLASS(TileHelperTests)
+   {
+      TEST_METHOD(ToTiles1D)
+      {
+         // A tile is made of 2 physical units.
+         using float2Helper = typename tile_helpers<int, float, 2>;
+
+         Assert::AreEqual(1, float2Helper::to_tiles(2.0f),
+                          L"2 meters did not scale to 1 tile.");
+
+         // 1/2 physical unit per tile.
+         using floatHalfHelper = typename tile_helpers<int, float, 1, 2>;
+         Assert::AreEqual(1, floatHalfHelper::to_tiles(0.5),
+                          L"1/2 meters did not scale to 1 tile.");
+
+         Assert::AreEqual(4, floatHalfHelper::to_tiles(2.0f),
+                          L"2 meters did not scale to 4 tiles.");
+      }
+
+      TEST_METHOD(ToTilesVector)
+      {
+         // A tile is made of 2 physical units.
+         using float2Helper = typename tile_helpers<int, float, 2>;
+
+         auto x1 = DirectX::XMVectorSet(1.0f, 2.0f, 3.0f, 4.0f);
+         auto x1X = DirectX::XMVectorSet(1.0f, 1.0f, 2.0f, 2.0f);
+
+
+         using helper = typename tile_helpers<int, float, 2>;
+
+         Assert::IsTrue(x1X == helper::to_tiles(x1),
+                        L"X1 was not transformed properly.");
+      }
+
+      TEST_METHOD(ScaleXForm)
+      {
+         // 2 tiles per physical unit
+         using floatHalfHelper = typename tile_helpers<int, float, 1, 2>;
+         auto xForm = floatHalfHelper::tile_scale();
+
+         auto expected = DirectX::XMMatrixSet(
+            2.0f, 0.0f, 0.0f, 0.0f,
+            0.0f, 2.0f, 0.0f, 0.0f,
+            0.0f, 0.0f, 2.0f, 0.0f,
+            0.0f, 0.0f, 0.0f, 1.0f
+         );
+
+         Assert::AreEqual(expected, xForm);
+      }
+   };
+}

--- a/Tests/QGL_Math.UnitTests/approx_equal_tests.cpp
+++ b/Tests/QGL_Math.UnitTests/approx_equal_tests.cpp
@@ -34,11 +34,11 @@ namespace QGL_Math_Unit_Tests
             "45681 round 1000 should be 46000");
 
          //Round 0.5 to the nearest 1 => 1
-         Assert::IsTrue(approx_equal(round_up(0.5, 1.0), 1.0),
+         Assert::IsTrue(approx_equal(round_up(0.5, 1.0), 1.0, DBL_EPSILON),
             L"0.5 round 1 should be close to 1");
 
          //Round 0.5f to the nearest 0.1f => 0.5f
-         Assert::IsTrue(approx_equal(round_up(0.5f, 0.1f), 0.5f),
+         Assert::IsTrue(approx_equal(round_up(0.5f, 0.1f), 0.5f, FLT_EPSILON),
             L"0.5 round 0.1 should be 0.5");
       }
 
@@ -51,10 +51,10 @@ namespace QGL_Math_Unit_Tests
       TEST_METHOD(FloatApproxEqual)
       {
          //Test with the default epsilon.
-         Assert::IsTrue(approx_equal(1.0f, 1.0f),
+         Assert::IsTrue(approx_equal(1.0f, 1.0f, FLT_EPSILON),
             L"1.0 and 1.0 should be equal.");
 
-         Assert::IsFalse(approx_equal(1.0f, 0.9999f),
+         Assert::IsFalse(approx_equal(1.0f, 0.9999f, FLT_EPSILON),
             L"1.0 and 0.9999 should not be equal.");
 
          //Test with custom epsilon.
@@ -66,10 +66,10 @@ namespace QGL_Math_Unit_Tests
       TEST_METHOD(DoubleApproxEqual)
       {
          //Test with the default epsilon.
-         Assert::IsTrue(approx_equal(1.0, 1.0),
+         Assert::IsTrue(approx_equal(1.0, 1.0, DBL_EPSILON),
             L"1.0 and 1.0 should be equal.");
 
-         Assert::IsFalse(approx_equal(1.0, 0.9999),
+         Assert::IsFalse(approx_equal(1.0, 0.9999, DBL_EPSILON),
             L"1.0 and 0.9999 should not be equal.");
 
          //Test with custom epsilon.

--- a/Tests/QGL_Math.UnitTests/dx_comparator_tests.cpp
+++ b/Tests/QGL_Math.UnitTests/dx_comparator_tests.cpp
@@ -113,5 +113,18 @@ namespace QGL_Math_Unit_Tests
          Assert::IsTrue(s1 != s2, L"s1 and s2 should not be equal.");
          Assert::IsTrue(s1 != s3, L"s1 and s3 should not be equal.");
       }
+
+      TEST_METHOD(DXHardwareVectorEquals)
+      {
+         auto x1 = DirectX::XMVectorSet(1.0f, 2.0f, 3.0f, 4.0f);
+         auto x1Copy = DirectX::XMVectorSet(1.0f, 2.0f, 3.0f, 4.0f);
+         auto x2 = DirectX::XMVectorSet(1.0f, 2.0f, 3.0f, 5.0f);
+
+         Assert::IsTrue(x1 == x1Copy,
+                        L"X1 does not equal itself.");
+
+         Assert::IsTrue(x1 != x2,
+                        L"X1 should not equal x2");
+      }
    };
 }

--- a/Tests/QGL_Math.UnitTests/pch.h
+++ b/Tests/QGL_Math.UnitTests/pch.h
@@ -1,17 +1,50 @@
 ﻿#pragma once
+#include <QGLMath.h>
 #include <collection.h>
 #include <ppltasks.h>
 #include "UnitTestApp.xaml.h"
 #include "CPPUnitTest.h"
-#include <QGLMath.h>
 
 namespace Microsoft::VisualStudio::CppUnitTestFramework
 {
    template<> static std::wstring ToString<qgl::math::rational<int>>
-      (const qgl::math::rational<int>& r)
+   (const qgl::math::rational<int>& r)
    {
       std::wstringstream ws;
       ws << r.numerator() << '/' << r.denominator();
+      return ws.str();
+   }
+
+   template<> static std::wstring ToString<DirectX::XMVECTOR>(
+      const DirectX::XMVECTOR& v)
+   {
+      using namespace DirectX;
+      std::wstringstream ws;
+      ws << "<" << XMVectorGetX(v) << ", " << XMVectorGetY(v) << ", " <<
+         XMVectorGetZ(v) << ", " << XMVectorGetW(v) << ">";
+      return ws.str();
+   }
+
+   template<> static std::wstring ToString<DirectX::XMMATRIX>(
+      const DirectX::XMMATRIX& m)
+   {
+      using namespace DirectX;
+      std::wstringstream ws;
+
+      XMFLOAT4X4 inspect;
+      XMStoreFloat4x4(&inspect, m);
+
+      for (size_t row = 0; row < 4; row++)
+      {
+         for (size_t col = 0; col < 4; col++)
+         {
+            auto f = inspect(row, col);
+            ws << f << " ";
+         }
+
+         ws << '\n';
+      }
+
       return ws.str();
    }
 }


### PR DESCRIPTION
Remove some constexpr where it isn't viable.
Remove default epsilon arguments since they weren't valid.
Add comparators for more DirectX types.

Update tests since epsilon is no longer a default argument.

Add tile helper class to convert physical units to tile units.
Add tile helper tests.

Fix a few other compiler warnings.